### PR TITLE
Update nginx.conf

### DIFF
--- a/srcs/services/nginx/conf/nginx.conf
+++ b/srcs/services/nginx/conf/nginx.conf
@@ -3,10 +3,10 @@
 server {
 	#<listen> is one of the ways to identify the correct server context within a configuration
 	#by default TLS/SSL connections use port 443, so its out port to listen
-	#for ip4
+	#for ip4 & 6
 	listen 443 ssl;
 	#for ip6
-	listen [::]:443 ssl;
+	#listen [::]:443 ssl;
 
 	#website name
 	server_name rkultaev.42.fr;


### PR DESCRIPTION
"listen [::]:443 ssl;" is obsolete when you have "listen 443 ssl;" because "listen 443 ssl;" accounts for both ipv4 AND ipv6